### PR TITLE
[HOPSWORKS-1405] Registration NOT done yet with Consul. Provide alternative URL to csr.py

### DIFF
--- a/providers/opendistro.rb
+++ b/providers/opendistro.rb
@@ -20,6 +20,7 @@ action :install_security do
   end
 
   kagent_keys "generate elastic admin certificate" do
+    hopsworks_alt_url new_resource.hopsworks_alt_url
     action :generate_elastic_admin_certificate
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -142,7 +142,15 @@ directory node['elastic']['data_dir'] do
   recursive true
 end
 
+hopsworks_alt_url = "https://#{private_recipe_ip("hopsworks","default")}:8181"
+if node.attribute? "hopsworks"
+  if node["hopsworks"].attribute? "https" and node["hopsworks"]['https'].attribute? ('port')
+    hopsworks_alt_url = "https://#{private_recipe_ip("hopsworks","default")}:#{node['hopsworks']['https']['port']}"
+  end
+end
+
 elastic_opendistro 'opendistro_security' do
+  hopsworks_alt_url hopsworks_alt_url
   action :install_security
 end
 

--- a/resources/opendistro.rb
+++ b/resources/opendistro.rb
@@ -1,3 +1,4 @@
 actions :install_security
 
 default_action :install_security
+attribute :hopsworks_alt_url, :kind_of => String, default: nil


### PR DESCRIPTION
**NOTE**: Elasticsearch is **NOT** yet registered with the service discovery system.

Just necessary changes to generate certificates