### PR TITLE
[HOPSWORKS-1731] Data scientists cannot install Python libs due to kibana permissions error

### DIFF
--- a/templates/default/roles.yml.erb
+++ b/templates/default/roles.yml.erb
@@ -114,6 +114,7 @@ elastic_exporter_hopsworks:
       - ".kibana_*_${attr.jwt.pn}"
       allowed_actions:
         - read
+        - write
         - index
         - get
     - index_patterns:


### PR DESCRIPTION
tests: https://github.com/logicalclocks/hops-testing/pull/683