### PR TITLE
[HWORKS-655] Reissue elkadmin certificate when restoring backup but still do not issue a new one when upgrading

### DIFF
--- a/providers/opensearch.rb
+++ b/providers/opensearch.rb
@@ -23,6 +23,13 @@ action :install_security do
     hopsworks_alt_url hopsworks_alt_url
     action :generate_x509
     not_if { node["kagent"]["enabled"] == "false" }
+    # We can't regenerate elkadmin certificate because the x509 Subject
+    # has hardcoded OU in opensearch.yml admin_dn
+    # But also we don't need to.
+    #
+    # Essentially execute this block only on fresh installations or restore
+    # from backup
+    not_if { conda_helpers.is_upgrade && !rondb_restoring_backup() }
   end
 
   kstore_file, tstore_file = x509_helper.get_user_keystores_name(node['elastic']['user'])


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-655